### PR TITLE
add optional fastp_path for local version of fastp with a patch

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -24,6 +24,7 @@ params {
     max_time   = '6.h'
 
     outputDir = "test_output"
+    fastp_path = null
 
     }
 

--- a/modules/fastp.nf
+++ b/modules/fastp.nf
@@ -14,6 +14,7 @@ process fastp {
         tuple val("${task.process}"), val('fastp'), eval('fastp --version 2>&1 | cut -f 2 -d " "'), topic: versions
     
     script:
+    def fastp_path = params.fastp_path ? params.fastp_path : ''
     def fastp_args = params.single_end ? "--out1 ${library}.1.trimmed.fastq.gz" : "--interleaved_in --out1 ${library}.1.trimmed.fastq.gz --out2 ${library}.2.trimmed.fastq.gz"
     """
     set +o pipefail
@@ -24,7 +25,7 @@ process fastp {
     echo \${trim_polyg} | awk '{ if (length(\$1)>0) { print "2-color instrument: poly-g trim mode on" } }'
     
     samtools fastq -n ${bam} | \\
-    fastp --stdin \\
+    ${fastp_path}fastp --stdin \\
                     -l 2 -Q \${trim_polyg} \\
                     --thread 1 \\
                     --overrepresentation_analysis \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,7 @@ params {
     // NEB only
     path_to_ngs_agg           = null
     workflow_name_modifier    = null
-    fastp_path                = null 
+    //fastp_path                = null 
 
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,6 @@ params {
     // NEB only
     path_to_ngs_agg           = null
     workflow_name_modifier    = null
-    //fastp_path                = null 
 
 }
 
@@ -71,7 +70,7 @@ profiles {
     test { 
         includeConfig 'conf/test.config'
         conda.enabled          = true
-        //conda.useMicromamba    = true
+        conda.useMicromamba    = true
         conda.cacheDir         = "${projectDir}/.conda/envs"
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
     // NEB only
     path_to_ngs_agg           = null
     workflow_name_modifier    = null
+    fastp_path                = null 
 
 }
 
@@ -70,7 +71,7 @@ profiles {
     test { 
         includeConfig 'conf/test.config'
         conda.enabled          = true
-        conda.useMicromamba    = true
+        //conda.useMicromamba    = true
         conda.cacheDir         = "${projectDir}/.conda/envs"
     }
 }


### PR DESCRIPTION
Adds an optional fastp_path (to be supplied in the seq shepherd config), so that we can use the patched version of fastp including an adapter_dimer_reads category.  Otherwise the fastp in the conda environment will be used. 