### PR TITLE
Fix Nextflow 26 topic channel compilation

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,3 @@
-nextflow.preview.topic = true
 include { registerEmailNotifications }                        from './lib/notifications.nf'
 include { createVersionsFile }                                from './lib/versions.nf'
 include { format_ngs_agg_opts }                               from './modules/aggregate_results'


### PR DESCRIPTION
## Problem

Nextflow 26.04.6 rejects `nextflow.preview.topic`, causing both `main.nf` tests to fail during compilation. The three `fastq_to_ubam.nf` tests pass.

## Fix

Remove the preview flag. Topic channels are native in currently supported Nextflow versions.