### PR TITLE
Add pair_mode column to tasmanian output (read vs insert)

### DIFF
--- a/modules/tasmanian.nf
+++ b/modules/tasmanian.nf
@@ -2,7 +2,7 @@ process tasmanian {
     label 'medium_cpu'
     tag { library }
     publishDir "${params.outputDir}/stats/tasmanian"
-    conda "bioconda::samtools=1.22 bioconda::tasmanian-mismatch=1.0.9"
+    conda "bioconda::tasmanian-mismatch=2.0.5"
 
     errorStrategy { retry < 1 ? 'retry' : 'terminate' }
     maxRetries 1
@@ -15,14 +15,18 @@ process tasmanian {
 
     output:
         tuple val(library), path("${library}.tasmanian.csv"), emit: for_agg
-        tuple val("${task.process}"), val('samtools'), eval('samtools --version | head -n 1 | sed \'s/^samtools //\''), topic: versions
-        tuple val("${task.process}"), val('tasmanian'), val('*should be* 1.0.9'), topic: versions
+        tuple val("${task.process}"), val('tasmanian-mismatch'), val('*should be* 2.0.5'), topic: versions
 
     script:
     """
     set +e
     set +o pipefail
-    samtools view -q 30 -F 3840 ${bam} | head -n 2000000 | run_tasmanian -r ${genome_fa} > ${library}.tasmanian.csv
+    tasmanian-mismatch ${bam} ${genome_fa} \
+        --position-mode read \
+        --min-base-quality 20 \
+        --min-map-quality 30 \
+        -F 3840 \
+        -o ${library}.tasmanian.csv
     """
 
 }


### PR DESCRIPTION
Adds pair_mode column to tasmanian output, distinguishing read vs insert level positional counts.